### PR TITLE
Add validation against forbidden chars in OAuth(2)RequestValidator

### DIFF
--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Security/OAuth2RequestValidator.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Security/OAuth2RequestValidator.cs
@@ -12,6 +12,7 @@ namespace Intuit.Ipp.Security
     using System.Configuration;
     using System.Net;
     using System.Security.Cryptography;
+    using System.Text.RegularExpressions;
     using DevDefined.OAuth.Consumer;
     using DevDefined.OAuth.Framework;
     using Intuit.Ipp.Exception;
@@ -26,32 +27,29 @@ namespace Intuit.Ipp.Security
         /// </summary>
         private const string AuthorizationHeader = "Authorization";
 
-
-
         /// <summary>
         /// The O auth signature method.
         /// </summary>
         private string oauthSignatureMethod;
 
-
         /// <summary>
         /// Initializes a new instance of the <see cref="OAuth2RequestValidator"/> class.
         /// </summary>
-        /// <param name="accessToken">The bearer access token.</param>        
+        /// <param name="accessToken">The bearer access token.</param>
         public OAuth2RequestValidator(string accessToken)
         {
             if (string.IsNullOrWhiteSpace(accessToken))
             {
                 throw new InvalidTokenException("Access token cannot be null or empty.");
             }
-
+            // only letters, digits, underscore and dash allowed
+            if (!Regex.IsMatch(accessToken, @"^[\w-]+$"))
+            {
+                throw new InvalidTokenException("Access token contains forbidden char.");
+            }
 
             this.AccessToken = accessToken;
-
         }
-
-
-
 
         /// <summary>
         /// Gets or sets the access token.
@@ -91,10 +89,5 @@ namespace Intuit.Ipp.Security
             string oauthHeader = string.Format("Bearer {0}", this.AccessToken);
             webRequest.Headers.Add(AuthorizationHeader, oauthHeader);
         }
-
-
-
-
     }
 }
-

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Security/OAuthRequestValidator.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Security/OAuthRequestValidator.cs
@@ -25,10 +25,11 @@ namespace Intuit.Ipp.Security
     using System.Configuration;
     using System.Net;
     using System.Security.Cryptography;
+    using System.Text.RegularExpressions;
     using DevDefined.OAuth.Consumer;
     using DevDefined.OAuth.Framework;
     using Intuit.Ipp.Exception;
-    
+
     /// <summary>
     /// OAuth implementation for Request validate contract.
     /// </summary>
@@ -43,13 +44,13 @@ namespace Intuit.Ipp.Security
         /// The O auth signature method.
         /// </summary>
         private string oauthSignatureMethod;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="OAuthRequestValidator"/> class.
         /// </summary>
         /// <param name="accessToken">The access token.</param>
         /// <param name="accessTokenSecret">The access token secret.</param>
-        /// <param name="consumerKey">The consumer key.</param> 
+        /// <param name="consumerKey">The consumer key.</param>
         /// <param name="consumerSecret">The consumer secret.</param>
         public OAuthRequestValidator(string accessToken, string accessTokenSecret, string consumerKey, string consumerSecret)
         {
@@ -57,20 +58,27 @@ namespace Intuit.Ipp.Security
             {
                 throw new InvalidTokenException("Access token cannot be null or empty.");
             }
-
             if (string.IsNullOrWhiteSpace(accessTokenSecret))
             {
                 throw new InvalidTokenException("Access token secret cannot be null or empty.");
+            }
+            // only letters, digits, underscore and dash allowed
+            if (!Regex.IsMatch(accessToken, @"^[\w-]+$"))
+            {
+                throw new InvalidTokenException("Access token contains forbidden char.");
             }
 
             if (string.IsNullOrWhiteSpace(consumerKey))
             {
                 throw new InvalidTokenException("Consumer key cannot be null or empty.");
             }
-
             if (string.IsNullOrWhiteSpace(consumerSecret))
             {
                 throw new InvalidTokenException("Consumer key secret cannot be null or empty.");
+            }
+            if (!Regex.IsMatch(consumerSecret, @"^[\w-]+$"))
+            {
+                throw new InvalidTokenException("Consumer key contains forbidden char.");
             }
 
             this.AccessToken = accessToken;
@@ -129,7 +137,7 @@ namespace Intuit.Ipp.Security
         /// The additional parameters.
         /// </value>
         public NameValueCollection AdditionalParameters { get; set; }
-        
+
         /// <summary>
         /// Gets or sets the key.
         /// </summary>
@@ -164,21 +172,18 @@ namespace Intuit.Ipp.Security
         //    oauthSession.AccessToken = this.CreateAccessToken();
         //    string oauthHeader = this.GetOAuthHeaderForRequest(oauthSession, webRequest);
         //    webRequest.Headers.Add(AuthorizationHeader, oauthHeader);
-        //    webRequest.ContentType = "application/x-www-form-urlencoded; charset=utf-8";   
+        //    webRequest.ContentType = "application/x-www-form-urlencoded; charset=utf-8";
         //    return webRequest as HttpWebRequest;
         //}
 
-
         ///// <summary>
-        ///// 
+        /////
         ///// </summary>
         ///// <param name="requestBody"></param>
         ///// <param name="httpWebRequest"></param>
         ///// <returns></returns>
         //public string GetDevDefinedOAuth1Header(string requestBody, string httpWebRequest)
         //{
-
-
         //}
 
         /// <summary>


### PR DESCRIPTION
Playing with encrypted token value in db I catch interesting exception: 

```
System.ArgumentException
   в System.Net.WebHeaderCollection.CheckBadChars(String name, Boolean isHeaderValue)
   в System.Net.WebHeaderCollection.Add(String name, String value)
   в Intuit.Ipp.Security.OAuth2RequestValidator.Authorize(WebRequest webRequest, String requestBody)
   в Intuit.Ipp.Core.Rest.RestHandler.PrepareRequest(RequestParameters requestParameters, Object requestBody, String oauthRequestUri, Boolean includeRequestId)
   в Intuit.Ipp.Core.Rest.SyncRestHandler.PrepareRequest(RequestParameters requestParameters, Object requestBody, String oauthRequestUri, Boolean includeRequestId)
   в Intuit.Ipp.DataService.DataService.Add[T](T entity)
```

That is because decrypted token was starting from "z;c�n'���".

I do not know how really your tokens generated, but looks like `^[\w-]+$` is enough to validate it.