### PR TITLE
Use FileShare.ReadWrite in LogPlatformRequests to allow parallel requests to work with same file

### DIFF
--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/LogRequestsToDisk.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/LogRequestsToDisk.cs
@@ -90,7 +90,7 @@ namespace Intuit.Ipp.Core.Rest
                 {
                     Encoding encoder = Encoding.GetEncoding("utf-8", new EncoderExceptionFallback(), new DecoderExceptionFallback());
                     byte[] data = encoder.GetBytes(xml);
-                    using (FileStream fs = new FileStream(filePath, FileMode.Append, FileAccess.Write))
+                    using (FileStream fs = new FileStream(filePath, FileMode.Append, FileAccess.ReadWrite))
                     {
                         fs.Write(data, 0, data.Length);
                     }


### PR DESCRIPTION
sorry, but #21 was only half of required fixes to log many requests. Now we do not try to create file, but still cannot use it:

```
System.IO.IOException : The process cannot access the file "D:\logs\Request-636625903146640576.txt" because it is being used by another process.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access)
   at Intuit.Ipp.Core.Rest.LogRequestsToDisk.LogPlatformRequests(String xml, Boolean isRequest)
```

this fix based on https://stackoverflow.com/questions/897796/how-do-i-open-an-already-opened-file-with-a-net-streamreader