### PR TITLE
Adding GetEntitlements to DataService

### DIFF
--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.DataService.Test/DataServiceQboTest.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.DataService.Test/DataServiceQboTest.cs
@@ -60,10 +60,25 @@ namespace Intuit.Ipp.DataService.Test
             dataServiceTestCases = new DataServiceTestCases(context);
             
         }
+        
+        [TestMethod()]
+        public void GetEntitlements()
+        {
+            try
+            {
+                EntitlementInfo entitlementInfo = dataServiceTestCases.GetEntitlements();
+                Assert.IsNotNull(entitlementInfo);
+                Assert.IsTrue(entitlementInfo.Entitlements.Count() > 0);
+            }
+            catch (System.Exception ex)
+            {
+                Assert.Fail(ex.ToString());
+            }
+        }
 
         #region Add Test
 
-      
+
         [TestMethod()]
         public void AddTest()
         {

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.DataService.Test/DataServiceTestCases.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.DataService.Test/DataServiceTestCases.cs
@@ -59,6 +59,11 @@ namespace Intuit.Ipp.DataService.Test
             return this.dataService.FindAll(entity, startPosition, maxResults);
         }
 
+        internal EntitlementInfo GetEntitlements()
+        {
+            return this.dataService.GetEntitlements();
+        }
+
         internal IEntity FindByIdEntity(IEntity entity)
         {
             return this.dataService.FindById(entity);

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.DataService/DataService.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.DataService/DataService.cs
@@ -29,6 +29,7 @@ namespace Intuit.Ipp.DataService
     using System.Linq;
     using System.Net;
     using System.Reflection;
+    using System.Xml;
     using Intuit.Ipp.Core;
     using Intuit.Ipp.Core.Rest;
     using Intuit.Ipp.Data;
@@ -170,6 +171,37 @@ namespace Intuit.Ipp.DataService
 
 
         #endregion
+
+        /// <summary>
+        /// Gets entitlements for the current realm. Entitlements are described here: https://developer.intuit.com/docs/api/accounting/entitlements
+        /// </summary>
+        public EntitlementInfo GetEntitlements()
+        {
+            this.serviceContext.IppConfiguration.Logger.CustomLogger.Log(Diagnostics.TraceLevel.Info, "Called Method GetEntitlements.");
+            string uri = string.Format(CultureInfo.InvariantCulture, "/manage/entitlements/{0}/{1}", CoreConstants.VERSION, this.serviceContext.RealmId);
+            RequestParameters parameters = new RequestParameters(uri, HttpVerbType.GET, CoreConstants.CONTENTTYPE_APPLICATIONXML);
+
+            // Prepares request
+            HttpWebRequest request = this.restHandler.PrepareRequest(parameters, null);
+            string response = string.Empty;
+            try
+            {
+                // Gets response
+                response = this.restHandler.GetResponse(request);
+            }
+            catch (IdsException ex)
+            {
+                IdsExceptionManager.HandleException(ex);
+            }
+
+            CoreHelper.CheckNullResponseAndThrowException(response);
+            XmlDocument xmldoc = CoreHelper.ParseResponseIntoXml(response);
+            EntitlementInfo entitlementInfo = new EntitlementInfo(xmldoc.DocumentElement);
+
+            this.serviceContext.IppConfiguration.Logger.CustomLogger.Log(Diagnostics.TraceLevel.Info, "Finished Executing Method GetEntitlements.");
+
+            return entitlementInfo;
+        }
 
         #region Add
 

--- a/IPPDotNetDevKitCSV3/Tools/XsdExtension/Intuit.Ipp.Data/IppServiceEntities/Entitlement.cs
+++ b/IPPDotNetDevKitCSV3/Tools/XsdExtension/Intuit.Ipp.Data/IppServiceEntities/Entitlement.cs
@@ -35,7 +35,7 @@ namespace Intuit.Ipp.Data
         /// <param name="singleEntitlementNode">The single entitlement node.</param>
         public Entitlement(XmlNode singleEntitlementNode)
         {
-            this.Id = singleEntitlementNode.Attributes.GetNamedItem("id").InnerText;
+            this.Id = int.Parse(singleEntitlementNode.Attributes.GetNamedItem("id").InnerText);
             XmlNode n = singleEntitlementNode.SelectSingleNode("./name");
             if (n != null)
             {
@@ -46,15 +46,14 @@ namespace Intuit.Ipp.Data
 
             if (n != null)
             {
-                this.TermId = n.Attributes.GetNamedItem("id").InnerText;
-                this.Term = n.InnerText;
+                this.Term = n.InnerText.Equals("On");
             }
         }
 
         /// <summary>
         /// Gets unique identifier of entitlement.
         /// </summary>
-        public string Id { get; private set; }
+        public int Id { get; private set; }
 
         /// <summary>
         /// Gets the name.
@@ -64,13 +63,8 @@ namespace Intuit.Ipp.Data
         /// <summary>
         /// Gets the term.
         /// </summary>
-        public string Term { get; private set; }
-
-        /// <summary>
-        /// Gets the term id.
-        /// </summary>
-        public string TermId { get; private set; }
-
+        public bool Term { get; private set; }
+        
         /// <summary>
         /// Parses all the entitlement elements of the API_GetEntitlementValues response.
         /// </summary>
@@ -81,7 +75,7 @@ namespace Intuit.Ipp.Data
         public static List<Entitlement> ParseEntitlements(XmlNode node)
         {
             List<Entitlement> entitlements = new List<Entitlement>();
-            XmlNodeList entitlementNodes = node.SelectNodes("./entitlements/entitlement");
+            XmlNodeList entitlementNodes = node.SelectNodes("./Entitlement");
             if (entitlementNodes != null)
             {
                 foreach (XmlNode e in entitlementNodes)

--- a/IPPDotNetDevKitCSV3/Tools/XsdExtension/Intuit.Ipp.Data/IppServiceEntities/EntitlementInfo.cs
+++ b/IPPDotNetDevKitCSV3/Tools/XsdExtension/Intuit.Ipp.Data/IppServiceEntities/EntitlementInfo.cs
@@ -20,7 +20,6 @@
 ////*********************************************************
 namespace Intuit.Ipp.Data 
 {
-    using System;
     using System.Collections.Generic;
     using System.Xml;
 
@@ -38,65 +37,34 @@ namespace Intuit.Ipp.Data
         /// <param name="entitlementNode">The entitlement node.</param>
         public EntitlementInfo(XmlNode entitlementNode)
         {
-            XmlNode n = entitlementNode.SelectSingleNode("//appId");
+            XmlNode n = entitlementNode.SelectSingleNode("//QboCompany");
             if (n != null)
             {
-                this.AppId = n.InnerText;
+                this.QboCompany = bool.Parse(n.InnerText);
             }
 
-            n = entitlementNode.SelectSingleNode("//productId");
-            if (n != null)
-            {
-                this.ProductId = n.InnerText;
-            }
-
-            n = entitlementNode.SelectSingleNode("//planName");
+            n = entitlementNode.SelectSingleNode("//PlanName");
             if (n != null)
             {
                 this.PlanName = n.InnerText;
             }
 
-            n = entitlementNode.SelectSingleNode("//planType");
-            if (n != null)
-            {
-                this.PlanType = n.InnerText;
-            }
-
-            n = entitlementNode.SelectSingleNode("//maxUsers");
+            n = entitlementNode.SelectSingleNode("//MaxUsers");
             if (n != null)
             {
                 this.MaxUsers = int.Parse(n.InnerText);
             }
 
-            n = entitlementNode.SelectSingleNode("//currentUsers");
+            n = entitlementNode.SelectSingleNode("//CurrentUsers");
             if (n != null)
             {
                 this.CurrentUsers = int.Parse(n.InnerText);
             }
 
-            n = entitlementNode.SelectSingleNode("//daysRemainingTrial");
+            n = entitlementNode.SelectSingleNode("//DaysRemainingTrial");
             if (n != null)
             {
                 this.DaysRemaining = int.Parse(n.InnerText);
-            }
-
-            n = entitlementNode.SelectSingleNode("//fee");
-            if (n != null)
-            {
-                this.Fee = double.Parse(n.InnerText);
-            }
-
-            n = entitlementNode.SelectSingleNode("//betaExpirationDate");
-            if (n != null)
-            {
-                // comes in longMonth DD, YYYY  format (e.g. June 10,2010)
-                this.BetaExpirationDate = DateTime.Parse(n.InnerText);
-            }
-
-            n = entitlementNode.SelectSingleNode("//currentFileUsage");
-            if (n != null)
-            {
-                this.CurrentFileUsage = long.Parse(n.InnerText);
             }
 
             this.Entitlements = Entitlement.ParseEntitlements(entitlementNode);
@@ -107,30 +75,14 @@ namespace Intuit.Ipp.Data
         #region Properties
 
         /// <summary>
-        /// Gets the app id.
+        /// Check if the company is a QuickBooks Online company. false is returned if not a QuickBooks Online company, the company exists in the Intuit ecosystem, but is not a QuickBooks Online company, or the company is a QuickBooks Online company, but the current user does not belong to the company.
         /// </summary>
-        public string AppId { get; private set; }
-
-        /// <summary>
-        /// Gets the product id.
-        /// </summary>
-        public string ProductId { get; private set; }
-
+        public bool QboCompany { get; private set; }
+       
         /// <summary>
         /// Gets the name of the plan.
         /// </summary>
-        /// <value>
-        /// The name of the plan.
-        /// </value>
         public string PlanName { get; private set; }
-
-        /// <summary>
-        /// Gets the type of the plan.
-        /// </summary>
-        /// <value>
-        /// The type of the plan.
-        /// </value>
-        public string PlanType { get; private set; }
 
         /// <summary>
         /// Gets the max users.
@@ -146,21 +98,6 @@ namespace Intuit.Ipp.Data
         /// Gets the days remaining.
         /// </summary>
         public int DaysRemaining { get; private set; }
-
-        /// <summary>
-        /// Gets the fee.
-        /// </summary>
-        public double Fee { get; private set; }
-
-        /// <summary>
-        /// Gets the beta expiration date.
-        /// </summary>
-        public DateTime BetaExpirationDate { get; private set; }
-
-        /// <summary>
-        /// Gets the current file usage.
-        /// </summary>
-        public long CurrentFileUsage { get; private set; }
 
         /// <summary>
         /// Gets the entitlements.


### PR DESCRIPTION
(created for Lendified Technologies https://www.lendified.com/)

This commit adds a method that gets Entitlements (https://developer.intuit.com/docs/api/accounting/entitlements) for the current realm.

This method is in the `DataService `class because that's where it is in the Java version -- https://github.com/intuit/QuickBooks-V3-Java-SDK/blob/c570d759f7de3dfb91034cbc35df16dd7c6507cb/ipp-v3-java-devkit/src/main/java/com/intuit/ipp/services/DataService.java#L929

There was already an `EntitlementsInfo` object in the SDK, but they aren't referenced anywhere, and appear to possibly reference an older version of the endpoint. I updated the case on some of the elements (`maxUsers` vs `MaxUsers`) . I also removed elements that no longer appear in the spec - `planType`, `appId`, `fee`, `betaExpirationDate `and `currentFileUsage`. Finally, I added `QboCompany`.

With `Entitlements`, these elements are now a child of `EntitlementsResponse`, rather than of `entitlements` They also no longer have `id` attribute on their `term` element.


Our team needed Entitlements to determine if a user was an Accountant or not, and we decided that adding this feature to the SDK would be best.
