### PR TITLE
adding logo to be used by the OS Site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 V3-DotNet-SDK
 =============
-
+<p align="center">
+    <img src="./os-project-logo.svg" width="150" alt="Logo"/>
+</p>
 IDG .NET SDK for QuickBooks V3
 (Class lib Project written in .NET Framework 4)
 

--- a/os-project-logo.svg
+++ b/os-project-logo.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 41.2 41.2" style="enable-background:new 0 0 41.2 41.2;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#2CA449;}
+</style>
+<path class="st0" d="M21,7C13.4,7,7.3,13.2,7.3,20.7c0,7.6,6.2,13.7,13.7,13.7c7.6,0,13.7-6.2,13.7-13.7C34.8,13.1,28.6,7,21,7z
+	 M20.2,29.7c-1.1,0-2-0.9-2-2c0-0.2,0-10.4,0-10.4h-1.8c-1.9,0-3.4,1.5-3.4,3.4s1.5,3.4,3.4,3.4h0.8v2h-0.8c-3,0-5.3-2.4-5.3-5.3
+	c0-3,2.4-5.3,5.3-5.3c1.8,0,3.8,0,3.8,0V29.7z M25.6,26.1c-1.8,0-3.8,0-3.8,0V11.7c1.1,0,2,0.9,2,2c0,0.2,0,10.4,0,10.4h1.8
+	c1.9,0,3.4-1.5,3.4-3.4s-1.5-3.4-3.4-3.4h-0.8v-2h0.8c3,0,5.3,2.4,5.3,5.3C30.9,23.7,28.5,26.1,25.6,26.1z"/>
+</svg>


### PR DESCRIPTION
In order to showcase project in the new Intuit Open Source site, we need a standard for the naming and location of the project's logo, "os-project-logo.svg" to be located in the root directory and used if possible in the readme file for branding alignment. A small version of the logo was created to be displayed on the OS Site (Content and visual designers were already in contact with some team members)