### PR TITLE
Rethrowing exceptions causes the original stack trace to be lost

### DIFF
--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core.Test/Common/Helper.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core.Test/Common/Helper.cs
@@ -47,7 +47,7 @@ namespace Intuit.Ipp.Core.Test.Common
                 }
                 else
                 {
-                    throw ex;
+                    throw;
                 }
             }
 

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/FaultHandler.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/FaultHandler.cs
@@ -285,7 +285,7 @@ namespace Intuit.Ipp.Core.Rest
                     return null;
                 }
 
-                throw ex;
+                throw;
             }
 
             // Return the fault.

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/SyncRestHandler.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/SyncRestHandler.cs
@@ -155,7 +155,7 @@ namespace Intuit.Ipp.Core.Rest
 
 
                 this.context.IppConfiguration.Logger.CustomLogger.Log(TraceLevel.Error, retryExceededException.ToString());
-                throw retryExceededException;
+                throw;
 
             }
             catch (WebException webException)

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.DataService.Test/Common/Helper.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.DataService.Test/Common/Helper.cs
@@ -52,7 +52,7 @@ namespace Intuit.Ipp.DataService.Test.Common
                 }
                 else
                 {
-                    throw ex;
+                    throw;
                 }
             }
 
@@ -223,8 +223,8 @@ namespace Intuit.Ipp.DataService.Test.Common
             }
             catch (IdsException idsEx)
             {
-                
-                throw idsEx;
+
+                throw;
             }
         }
 
@@ -263,7 +263,7 @@ namespace Intuit.Ipp.DataService.Test.Common
             catch (IdsException idsEx)
             {
 
-                throw idsEx;
+                throw;
             }
         }
         
@@ -311,7 +311,7 @@ namespace Intuit.Ipp.DataService.Test.Common
             catch (IdsException idsEx)
             {
 
-                throw idsEx;
+                throw;
             }
         }
     }

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.DataService.Test/DataServiceTestCases.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.DataService.Test/DataServiceTestCases.cs
@@ -47,7 +47,7 @@ namespace Intuit.Ipp.DataService.Test
             catch (Intuit.Ipp.Exception.IdsException ex)
             {
                 this.serviceContext.IppConfiguration.Message.Request.SerializationFormat = Core.Configuration.SerializationFormat.Xml;
-                throw ex;
+                throw;
             }
 
             this.serviceContext.IppConfiguration.Message.Request.SerializationFormat = Core.Configuration.SerializationFormat.Xml;

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.EntitlementService.Test/Common/Helper.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.EntitlementService.Test/Common/Helper.cs
@@ -51,7 +51,7 @@ namespace Intuit.Ipp.EntitlementService.Test.Common
                 }
                 else
                 {
-                    throw ex;
+                    throw;
                 }
             }
 

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.GlobalTaxServiceTest/Common/Helper.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.GlobalTaxServiceTest/Common/Helper.cs
@@ -51,7 +51,7 @@ namespace Intuit.Ipp.GlobalTaxService.Test.Common
                 }
                 else
                 {
-                    throw ex;
+                    throw;
                 }
             }
 

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.OAuth2PlatformClient.Test/Common/Helper.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.OAuth2PlatformClient.Test/Common/Helper.cs
@@ -46,7 +46,7 @@ namespace Intuit.Ipp.OAuth2PlatformClient.Test.Common
                 }
                 else
                 {
-                    throw ex;
+                    throw;
                 }
             }
 

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.QueryFilter.Test/Common/Helper.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.QueryFilter.Test/Common/Helper.cs
@@ -45,7 +45,7 @@ namespace Intuit.Ipp.QueryFilter.Test.Common
                 }
                 else
                 {
-                    throw ex;
+                    throw;
                 }
             }
 

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.ReportService.Test/Common/Helper.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.ReportService.Test/Common/Helper.cs
@@ -45,7 +45,7 @@ namespace Intuit.Ipp.ReportService.Test.Common
                 }
                 else
                 {
-                    throw ex;
+                    throw;
                 }
             }
 

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Security.Test/Common/Helper.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Security.Test/Common/Helper.cs
@@ -44,7 +44,7 @@ namespace Intuit.Ipp.Security.Test.Common
                 }
                 else
                 {
-                    throw ex;
+                    throw;
                 }
             }
 

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Utility.Test/Common/Helper.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Utility.Test/Common/Helper.cs
@@ -51,7 +51,7 @@ namespace Intuit.Ipp.Utility.Test.Common
                 }
                 else
                 {
-                    throw ex;
+                    throw;
                 }
             }
 


### PR DESCRIPTION
Reference: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/throw

Quite a minor change, but useful when trying to track down problems. Rethrowing the exception in the manner used before this PR removes the existing Stack Trace and replaces with with a new one