### PR TITLE
Handle NullReference

### DIFF
--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.DataService/Batch.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.DataService/Batch.cs
@@ -137,6 +137,24 @@ namespace Intuit.Ipp.DataService
             }
         }
 
+        /// <summary>
+        /// Tries to get the <see cref="Intuit.Ipp.DataService.IntuitBatchResponse"/> with the specified id
+        /// </summary>
+        /// <param name="id"> unique batchitem id. </param>
+        /// <returns>True if the item was found, otherwise false</returns>
+        public bool TryGetValue(string id, out IntuitBatchResponse intuitBatchResponse)
+        {
+            BatchItemResponse batchresponse = this.batchResponses.FirstOrDefault(item => item.bId == id);
+            if (batchresponse == null)
+            {
+                intuitBatchResponse = null;
+                return false;
+            }
+
+            intuitBatchResponse = ProcessBatchItemResponse(batchresponse);
+            return true;
+        }
+
         #endregion
 
         #region methods

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.DataService/Batch.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.DataService/Batch.cs
@@ -644,27 +644,26 @@ namespace Intuit.Ipp.DataService
                     if (entity == null)
                     {
                         QueryResponse queryResponse = batchitemResponse.AnyIntuitObject as QueryResponse;
-                        result.ResponseType = ResponseType.Query;
-                        QueryResponse returnValue = new QueryResponse();
-                        returnValue.totalCount= queryResponse.totalCount;
-                        returnValue.totalCountSpecified= queryResponse.totalCountSpecified;
-                        result.QueryResponse = returnValue;
-                        
-
-
-                        if (queryResponse.AnyIntuitObjects != null && queryResponse.AnyIntuitObjects.Count() > 0)
+                        if (queryResponse != null)
                         {
-                            foreach (object obj in queryResponse.AnyIntuitObjects)
-                            { 
-                                result.AddEntities(obj as IEntity);
+                            result.ResponseType = ResponseType.Query;
+                            QueryResponse returnValue = new QueryResponse();
+                            returnValue.totalCount = queryResponse.totalCount;
+                            returnValue.totalCountSpecified = queryResponse.totalCountSpecified;
+                            result.QueryResponse = returnValue;
+
+                            if (queryResponse.AnyIntuitObjects != null && queryResponse.AnyIntuitObjects.Count() > 0)
+                            {
+                                foreach (object obj in queryResponse.AnyIntuitObjects)
+                                {
+                                    result.AddEntities(obj as IEntity);
+                                }
                             }
-
                         }
-                       
-                        
-                            
-                        
-
+                        else
+                        {
+                            //Not sure how we end up here
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
We received a nullreference in this code (possibly due to a bug in the API)

**Request**
`<IntuitBatchRequest xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schema.intuit.com/finance/v3">
  <BatchItemRequest bId="b338d4a4-e44c-4ed6-9e39-fe8ba0075fb2" operation="create">
    <Payment>
      <TxnDate>2018-04-06</TxnDate>
      <Line>
        <Amount>0.2</Amount>
        <LinkedTxn>
          <TxnId>3598</TxnId>
          <TxnType>CreditMemo</TxnType>
        </LinkedTxn>
        <DetailType>PaymentLineDetail</DetailType>
      </Line>
      <Line>
        <Amount>0.2</Amount>
        <LinkedTxn>
          <TxnId>2345</TxnId>
          <TxnType>Invoice</TxnType>
        </LinkedTxn>
        <DetailType>PaymentLineDetail</DetailType>
      </Line>
      <CustomerRef name="Cash Sales" type="Customer">3</CustomerRef>
      <TotalAmt>0</TotalAmt>
    </Payment>
  </BatchItemRequest>
</IntuitBatchRequest>`

**Response**

`<?xml version="1.0" encoding="UTF-8" standalone="yes"?><IntuitResponse xmlns="http://schema.intuit.com/finance/v3" time="2019-09-23T02:52:13.827-07:00"><BatchItemResponse bId="b338d4a4-e44c-4ed6-9e39-fe8ba0075fb2"/></IntuitResponse>`