### PR TITLE
Cleaning up some typos in the XML comment param tags to remove some of the warnings.

### DIFF
--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/SyncRestHandler.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/SyncRestHandler.cs
@@ -273,7 +273,7 @@ namespace Intuit.Ipp.Core.Rest
             }
         }
 
-        // <summary>
+        /// <summary>
         /// Calls the rest service.
         /// </summary>
         /// <param name="request">The request.</param>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.GlobalTaxService/GlobalAsyncTaxService.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.GlobalTaxService/GlobalAsyncTaxService.cs
@@ -80,7 +80,7 @@ namespace Intuit.Ipp.GlobalTaxService
         /// <summary>
         /// Adds an entity (asynchronously) under the specified realm in an asynchronous manner. The realm must be set in the context.
         /// </summary>
-        /// <param name="entity">Entity to Add</param>
+        /// <param name="taxCode">Entity to Add</param>
         public void AddTaxCodeAsync(Intuit.Ipp.Data.TaxService taxCode)
         {
             this.serviceContext.IppConfiguration.Logger.CustomLogger.Log(Diagnostics.TraceLevel.Info, "Called Method Add Asynchronously.");

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.GlobalTaxService/GlobalTaxServiceHelper.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.GlobalTaxService/GlobalTaxServiceHelper.cs
@@ -43,7 +43,7 @@ namespace Intuit.Ipp.GlobalTaxService
         /// <summary>
         /// Checks whether the entity passed has a type or not.
         /// </summary>
-        /// <param name="entity">CDM Entity.</param>
+        /// <param name="taxCodeName">CDM Entity.</param>
         /// <returns>True if the type exists or else false.</returns>
         internal static bool IsTypeNull(Intuit.Ipp.Data.TaxService taxCodeName)
         {

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.GlobalTaxService/Interface/IGlobalTaxService.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.GlobalTaxService/Interface/IGlobalTaxService.cs
@@ -37,9 +37,9 @@ namespace Intuit.Ipp.GlobalTaxService.Interface
         /// <summary>
         /// Adds TaxService entity under the specified realm. The realm must be set in the context.
         /// </summary>        
-        /// <param name="entity">TaxService entity to Add.</param>
+        /// <param name="taxcode">TaxService entity to Add.</param>
         /// <returns>Returns an updated version of the entity with updated identifier.</returns>
-        
+
         TaxService AddTaxCode(TaxService taxcode);
     }
 }

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.OAuth2PlatformClient/Client/TokenRevocationClient.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.OAuth2PlatformClient/Client/TokenRevocationClient.cs
@@ -60,7 +60,7 @@ namespace Intuit.Ipp.OAuth2PlatformClient
         /// </summary>
         /// <param name="endpoint">endpoint</param>
         /// <param name="clientId">clientId</param>
-        /// <param name="clientSecret"clientSecret></param>
+        /// <param name="clientSecret">clientSecret</param>
         /// <param name="innerHttpMessageHandler">innerHttpMessageHandler</param>
         public TokenRevocationClient(string endpoint, string clientId = "", string clientSecret = "", HttpMessageHandler innerHttpMessageHandler = null)
         {

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.OAuth2PlatformClient/Client/UserInfoResponse.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.OAuth2PlatformClient/Client/UserInfoResponse.cs
@@ -54,7 +54,7 @@ namespace Intuit.Ipp.OAuth2PlatformClient
         /// Handles exception response from UserInfo api call
         /// </summary>
         /// <param name="statusCode">statusCode</param>
-        /// <param name="reason">reason</param>
+        /// <param name="httpErrorReason">reason</param>
         public UserInfoResponse(HttpStatusCode statusCode, string httpErrorReason)
         {
             IsError = true;

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Utility/Serialization/IntuitConverter.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Utility/Serialization/IntuitConverter.cs
@@ -210,7 +210,7 @@ namespace Intuit.Ipp.Utility
         /// <param name="reader">json reader</param>
         /// <param name="objectType">objectType value</param>
         /// <param name="existingValue">existing value</param>
-        /// <param name="serliazer">serliazer value</param>
+        /// <param name="serializer">serializer value</param>
         /// <returns>void</returns>
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
@@ -378,7 +378,7 @@ namespace Intuit.Ipp.Utility
         /// <summary>
         /// CanConvert
         /// </summary>  
-        /// <param name="objecType">object Type value</param>
+        /// <param name="objectType">object Type value</param>
         /// <returns>void</returns>
         public override bool CanConvert(Type objectType)
         {


### PR DESCRIPTION
This PR tries to fix a few minor typos in the XML comment param tags that were causing warnings.