### PR TITLE
Remove unused Serilog dependency (DocumentDB)

### DIFF
--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/Intuit.Ipp.Core.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/Intuit.Ipp.Core.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
     <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Sinks.AzureDocumentDb" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Nupkg/Intuit.Ipp.Nupkg.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Nupkg/Intuit.Ipp.Nupkg.csproj
@@ -126,7 +126,6 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Sinks.AzureDocumentDb" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.OAuth2PlatformClient/Intuit.Ipp.OAuth2PlatformClient.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.OAuth2PlatformClient/Intuit.Ipp.OAuth2PlatformClient.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Sinks.AzureDocumentDb" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Test/SDKV3Test/Intuit.Ipp.Test.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Test/SDKV3Test/Intuit.Ipp.Test.csproj
@@ -23,7 +23,6 @@
        <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
        <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
       <PackageReference Include="Serilog" Version="2.9.0" />
-      <PackageReference Include="Serilog.Sinks.AzureDocumentDb" Version="4.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
       <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
       <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />


### PR DESCRIPTION
This is currently unused, and can be configured by the developer if the want to add this in at runtime

Related #108 