### PR TITLE
Add support for .Net Core 3.0 & 3.1

### DIFF
--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.OAuth2PlatformClient/Intuit.Ipp.OAuth2PlatformClient.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.OAuth2PlatformClient/Intuit.Ipp.OAuth2PlatformClient.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net472;net461</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="App.config" />


### PR DESCRIPTION
Just added a Target Framework of netstandard2.1 in OAuth Client csproj to target .Net Core 3.0 & 3.1