### PR TITLE
Fixes #216 - VS 2022 compilation error - Unable to load DLL 'Microsoft.DiaSymReader.Native.amd64.dll

### DIFF
--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core.Test/Intuit.Ipp.Core.Test.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core.Test/Intuit.Ipp.Core.Test.csproj
@@ -1,47 +1,48 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Remove="Initializer.cs" />
-    <Compile Remove="LocalConfigReaderTest.cs" />
-    <Compile Remove="TestHelper.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.0</TargetFramework>
+		<OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
+	<ItemGroup>
+		<Compile Remove="Initializer.cs" />
+		<Compile Remove="LocalConfigReaderTest.cs" />
+		<Compile Remove="TestHelper.cs" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.QueryFilter\Intuit.Ipp.QueryFilter.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.QueryFilter\Intuit.Ipp.QueryFilter.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="AppSettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TokenStore.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="AppSettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="TokenStore.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+	</ItemGroup>
 
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/Intuit.Ipp.Core.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/Intuit.Ipp.Core.csproj
@@ -1,32 +1,33 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Remove="app.config" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
+	<ItemGroup>
+		<None Remove="app.config" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="AppSettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+		<PackageReference Include="Serilog" Version="2.10.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Update="AppSettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+	</ItemGroup>
 
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.DataService.Test/Intuit.Ipp.DataService.Test.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.DataService.Test/Intuit.Ipp.DataService.Test.csproj
@@ -1,50 +1,51 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.0</TargetFramework>
+		<OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.QueryFilter\Intuit.Ipp.QueryFilter.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.QueryFilter\Intuit.Ipp.QueryFilter.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="AppSettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Resources\test.jpg">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Resources\testWriteBack.jpg">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TokenStore.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="AppSettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="Resources\test.jpg">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="Resources\testWriteBack.jpg">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="TokenStore.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+	</ItemGroup>
 
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.DataService/Intuit.Ipp.DataService.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.DataService/Intuit.Ipp.DataService.csproj
@@ -1,28 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Remove="RecurringTransactions.cs" />
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Remove="RecurringTransactions.cs" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+</ItemGroup>
 
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Diagnostics.Test/Intuit.Ipp.Diagnostics.Test.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Diagnostics.Test/Intuit.Ipp.Diagnostics.Test.csproj
@@ -1,29 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.0</TargetFramework>
+		<OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Remove="App.config" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Remove="App.config" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+	</ItemGroup>
 
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Diagnostics/Intuit.Ipp.Diagnostics.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Diagnostics/Intuit.Ipp.Diagnostics.csproj
@@ -1,31 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Remove="Interface\ISeriLogger.cs" />
-    <Compile Remove="SeriLogger.cs" />
-    <Compile Remove="SerilogLogger.cs" />
-  </ItemGroup>
-  <ItemGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
+	<ItemGroup>
+		<Compile Remove="Interface\ISeriLogger.cs" />
+		<Compile Remove="SeriLogger.cs" />
+		<Compile Remove="SerilogLogger.cs" />
+	</ItemGroup>
+	<ItemGroup>
 
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
 
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
 
-    <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include = "Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include = "Serilog.Sinks.File" Version="4.1.0" />
-    <PackageReference Include = "Serilog.Enrichers.Environment" Version="2.1.3" />
-    <PackageReference Include = "Serilog.Enrichers.Thread" Version="3.1.0" />
-    <PackageReference Include = "Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include = "Serilog.Settings.Configuration" Version="3.1.0" />
-    <PackageReference Include = "Serilog.Sinks.Debug" Version="2.0.0" />
-    <PackageReference Include = "Serilog.Sinks.Trace" Version="2.1.0" />
-    <PackageReference Include = "SerilogTraceListener" Version="3.2.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+		<PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
+		<PackageReference Include="Serilog" Version="2.10.0" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+		<PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+		<PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
+		<PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
+		<PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+		<PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
+		<PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />
+		<PackageReference Include="SerilogTraceListener" Version="3.2.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+	</ItemGroup>
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.EntitlementService.Test/Intuit.Ipp.EntitlementService.Test.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.EntitlementService.Test/Intuit.Ipp.EntitlementService.Test.csproj
@@ -1,47 +1,48 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.0</TargetFramework>
+		<OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Remove="App.config" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Remove="App.config" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.EntitlementService\Intuit.Ipp.EntitlementService.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.EntitlementService\Intuit.Ipp.EntitlementService.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="AppSettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TokenStore.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="AppSettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="TokenStore.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+	</ItemGroup>
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.EntitlementService/Intuit.Ipp.EntitlementService.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.EntitlementService/Intuit.Ipp.EntitlementService.csproj
@@ -1,20 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+</ItemGroup>
 
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Exception.Test/Intuit.Ipp.Exception.Test.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Exception.Test/Intuit.Ipp.Exception.Test.csproj
@@ -1,28 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.0</TargetFramework>
+		<OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+	</ItemGroup>
 
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Exception/Intuit.Ipp.Exception.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Exception/Intuit.Ipp.Exception.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+	</ItemGroup>
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.GlobalTaxService/Intuit.Ipp.GlobalTaxService.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.GlobalTaxService/Intuit.Ipp.GlobalTaxService.csproj
@@ -1,19 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+	</ItemGroup>
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.GlobalTaxServiceTest/Intuit.Ipp.GlobalTaxServiceTest.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.GlobalTaxServiceTest/Intuit.Ipp.GlobalTaxServiceTest.csproj
@@ -1,45 +1,46 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.0</TargetFramework>
+		<OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.GlobalTaxService\Intuit.Ipp.GlobalTaxService.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.QueryFilter\Intuit.Ipp.QueryFilter.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.GlobalTaxService\Intuit.Ipp.GlobalTaxService.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.QueryFilter\Intuit.Ipp.QueryFilter.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="AppSettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TokenStore.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="AppSettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="TokenStore.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+	</ItemGroup>
 
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Nupkg/Intuit.Ipp.Nupkg.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Nupkg/Intuit.Ipp.Nupkg.csproj
@@ -1,196 +1,197 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
-    <GeneratePackageOnBuild Condition="$(Configuration) == 'Release' ">true</GeneratePackageOnBuild>
-    <!--<GeneratePackageOnBuild>true</GeneratePackageOnBuild>-->
-    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
-    <LibTargetFrameworks>netstandard2.0;net472;net461</LibTargetFrameworks>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb;.xml</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <PackageId>IppDotNetSdkForQuickBooksApiV3</PackageId>
-    <AssemblyName>IppDotNetSdkForQuickBooksApiV3</AssemblyName>
-    <DocumentationFile>$(BaseOutputPath)$(AssemblyName).xml</DocumentationFile>
-    <MainVersion>14.6.2.0</MainVersion>
-    <PackageVersionSuffix>pre</PackageVersionSuffix>
-    <Version>$(MainVersion)-$(PackageVersionSuffix)</Version>
-    <Version>$(MainVersion)</Version>
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-    <NoBuild>true</NoBuild>
-    <IncludeBuildOutput>true</IncludeBuildOutput>
-    <AutoGenerateBindingRedirects>False</AutoGenerateBindingRedirects>
-    <Description>The IPP .NET SDK for QuickBooks V3 is a set of .NET classes that make it easier to call QuickBooks APIs. This is the .Net Standard 2.0 version of the .Net SDK</Description>
-    <Authors>Intuit</Authors>
-    <RepositoryUrl>https://github.com/intuit/QuickBooks-V3-DotNET-SDK</RepositoryUrl>
-    <PackageProjectUrl>https://developer.intuit.com/app/developer/qbo/docs/develop/sdks-and-samples-collections/net</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/intuit/QuickBooks-V3-DotNET-SDK/blob/master/License.md</PackageLicenseUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageReleaseNotes>https://github.com/intuit/QuickBooks-V3-DotNET-SDK/releases</PackageReleaseNotes>
-  </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
-    <ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.EntitlementService\Intuit.Ipp.EntitlementService.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.GlobalTaxService\Intuit.Ipp.GlobalTaxService.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient.Diagnostics\Intuit.Ipp.OAuth2PlatformClient.Diagnostics.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.QueryFilter\Intuit.Ipp.QueryFilter.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.ReportService\Intuit.Ipp.ReportService.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.Retry\Intuit.Ipp.Retry.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.WebHooksService\Intuit.Ipp.WebHooksService.csproj" PrivateAssets="all" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
+		<GeneratePackageOnBuild Condition="$(Configuration) == 'Release' ">true</GeneratePackageOnBuild>
+		<!--<GeneratePackageOnBuild>true</GeneratePackageOnBuild>-->
+		<TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
+		<LibTargetFrameworks>netstandard2.0;net472;net461</LibTargetFrameworks>
+		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb;.xml</AllowedOutputExtensionsInPackageBuildOutputFolder>
+		<PackageId>IppDotNetSdkForQuickBooksApiV3</PackageId>
+		<AssemblyName>IppDotNetSdkForQuickBooksApiV3</AssemblyName>
+		<DocumentationFile>$(BaseOutputPath)$(AssemblyName).xml</DocumentationFile>
+		<MainVersion>14.6.2.0</MainVersion>
+		<PackageVersionSuffix>pre</PackageVersionSuffix>
+		<Version>$(MainVersion)-$(PackageVersionSuffix)</Version>
+		<Version>$(MainVersion)</Version>
+		<DebugType>full</DebugType>
+		<DebugSymbols>true</DebugSymbols>
+		<NoBuild>false</NoBuild>
+		<IncludeBuildOutput>true</IncludeBuildOutput>
+		<AutoGenerateBindingRedirects>False</AutoGenerateBindingRedirects>
+		<Description>The IPP .NET SDK for QuickBooks V3 is a set of .NET classes that make it easier to call QuickBooks APIs. This is the .Net Standard 2.0 version of the .Net SDK</Description>
+		<Authors>Intuit</Authors>
+		<RepositoryUrl>https://github.com/intuit/QuickBooks-V3-DotNET-SDK</RepositoryUrl>
+		<PackageProjectUrl>https://developer.intuit.com/app/developer/qbo/docs/develop/sdks-and-samples-collections/net</PackageProjectUrl>
+		<PackageLicenseUrl>https://github.com/intuit/QuickBooks-V3-DotNET-SDK/blob/master/License.md</PackageLicenseUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+		<PackageReleaseNotes>https://github.com/intuit/QuickBooks-V3-DotNET-SDK/releases</PackageReleaseNotes>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+		<ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.EntitlementService\Intuit.Ipp.EntitlementService.csproj" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.GlobalTaxService\Intuit.Ipp.GlobalTaxService.csproj" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient.Diagnostics\Intuit.Ipp.OAuth2PlatformClient.Diagnostics.csproj" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.QueryFilter\Intuit.Ipp.QueryFilter.csproj" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.ReportService\Intuit.Ipp.ReportService.csproj" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.Retry\Intuit.Ipp.Retry.csproj" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.WebHooksService\Intuit.Ipp.WebHooksService.csproj" PrivateAssets="all" />
+	</ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472'">
-    <ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.EntitlementService\Intuit.Ipp.EntitlementService.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.GlobalTaxService\Intuit.Ipp.GlobalTaxService.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient.Diagnostics\Intuit.Ipp.OAuth2PlatformClient.Diagnostics.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all"/>
-    <ProjectReference Include="..\Intuit.Ipp.QueryFilter\Intuit.Ipp.QueryFilter.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.ReportService\Intuit.Ipp.ReportService.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.Retry\Intuit.Ipp.Retry.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.WebHooksService\Intuit.Ipp.WebHooksService.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461'">
-    <ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.EntitlementService\Intuit.Ipp.EntitlementService.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.GlobalTaxService\Intuit.Ipp.GlobalTaxService.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient.Diagnostics\Intuit.Ipp.OAuth2PlatformClient.Diagnostics.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.QueryFilter\Intuit.Ipp.QueryFilter.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.ReportService\Intuit.Ipp.ReportService.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.Retry\Intuit.Ipp.Retry.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
-    <ProjectReference Include="..\Intuit.Ipp.WebHooksService\Intuit.Ipp.WebHooksService.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
-  </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net472'">
+		<ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.EntitlementService\Intuit.Ipp.EntitlementService.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.GlobalTaxService\Intuit.Ipp.GlobalTaxService.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient.Diagnostics\Intuit.Ipp.OAuth2PlatformClient.Diagnostics.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.QueryFilter\Intuit.Ipp.QueryFilter.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.ReportService\Intuit.Ipp.ReportService.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.Retry\Intuit.Ipp.Retry.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.WebHooksService\Intuit.Ipp.WebHooksService.csproj" AdditionalProperties="TargetFramework=net472" PrivateAssets="all" />
+	</ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net461'">
+		<ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.EntitlementService\Intuit.Ipp.EntitlementService.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.GlobalTaxService\Intuit.Ipp.GlobalTaxService.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient.Diagnostics\Intuit.Ipp.OAuth2PlatformClient.Diagnostics.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.QueryFilter\Intuit.Ipp.QueryFilter.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.ReportService\Intuit.Ipp.ReportService.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.Retry\Intuit.Ipp.Retry.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
+		<ProjectReference Include="..\Intuit.Ipp.WebHooksService\Intuit.Ipp.WebHooksService.csproj" AdditionalProperties="TargetFramework=net461" PrivateAssets="all" />
+	</ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472'">
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
- 
-
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
-    <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
-    <PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />
-    <PackageReference Include="SerilogTraceListener" Version="3.2.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" /> 
-
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461'">
-
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net472'">
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+		<PackageReference Include="Serilog" Version="2.10.0" />
 
 
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
-    <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
-    <PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />
-    <PackageReference Include="SerilogTraceListener" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+		<PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+		<PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
+		<PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
+		<PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+		<PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
+		<PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />
+		<PackageReference Include="SerilogTraceListener" Version="3.2.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
 
-  </ItemGroup>
+	</ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net461'">
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
-    <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />
-    <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
-    <PackageReference Include="SerilogTraceListener" Version="3.2.0" />
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
-  </ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+		<PackageReference Include="Serilog" Version="2.10.0" />
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
 
-  <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">
-    <ItemGroup>
-      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
-    </ItemGroup>
-  </Target>
-  <Target Name="CopyPdbToPackage" Inputs="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" Outputs="%(ProjectReference.Identity)" AfterTargets="CopyProjectReferencesToPackage">
-    <PropertyGroup>
-      <CurrentReference>%(ProjectReference.Identity)</CurrentReference>
-      <CurrentReferenceName>$([System.IO.Path]::GetFileNameWithoutExtension($(CurrentReference)))</CurrentReferenceName>
-    </PropertyGroup>
+		<PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+		<PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
+		<PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
+		<PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+		<PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
+		<PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />
+		<PackageReference Include="SerilogTraceListener" Version="3.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
 
-    <ItemGroup>
-      <AllPdbItems Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('OriginalProjectReferenceItemSpec', '$(CurrentReference)'))" />
-      <PdbFiles Include="@(AllPdbItems -> '%(RelativeDir)%(Filename).pdb')" Condition="%(extension) == '.dll'" />
-    </ItemGroup>
+	</ItemGroup>
 
-    <Message Text="Copying @(PdbFiles ->'%(Identity)') to nupkg" Importance="high" Condition="'%(ProjectReference.NugetIgnore)'!='true'" />
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="Serilog" Version="2.10.0" />
+		<PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+		<PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
+		<PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
+		<PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+		<PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />
+		<PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
+		<PackageReference Include="SerilogTraceListener" Version="3.2.0" />
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
+	</ItemGroup>
 
-    <ItemGroup>
-      <TfmSpecificPackageFile Include="@(PdbFiles)" Condition="'%(ProjectReference.NugetIgnore)'!='true'">
-        <PackagePath>lib/$(TargetFramework)</PackagePath>
-      </TfmSpecificPackageFile>
-    </ItemGroup>
-  </Target>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
 
-  <Target Name="CopyXmlToPackage" Inputs="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" Outputs="%(ProjectReference.Identity)" AfterTargets="CopyProjectReferencesToPackage">
-    <PropertyGroup>
-      <CurrentReference>%(ProjectReference.Identity)</CurrentReference>
-      <CurrentReferenceName>$([System.IO.Path]::GetFileNameWithoutExtension($(CurrentReference)))</CurrentReferenceName>
-    </PropertyGroup>
+	<Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">
+		<ItemGroup>
+			<BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
+		</ItemGroup>
+	</Target>
+	<Target Name="CopyPdbToPackage" Inputs="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" Outputs="%(ProjectReference.Identity)" AfterTargets="CopyProjectReferencesToPackage">
+		<PropertyGroup>
+			<CurrentReference>%(ProjectReference.Identity)</CurrentReference>
+			<CurrentReferenceName>$([System.IO.Path]::GetFileNameWithoutExtension($(CurrentReference)))</CurrentReferenceName>
+		</PropertyGroup>
 
-    <ItemGroup>
-      <AllXmlItems Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('OriginalProjectReferenceItemSpec', '$(CurrentReference)'))" />
-      <XmlFiles Include="@(AllXmlItems -> '%(RelativeDir)%(Filename).xml')" Condition="%(extension) == '.dll'" />
-    </ItemGroup>
+		<ItemGroup>
+			<AllPdbItems Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('OriginalProjectReferenceItemSpec', '$(CurrentReference)'))" />
+			<PdbFiles Include="@(AllPdbItems -> '%(RelativeDir)%(Filename).pdb')" Condition="%(extension) == '.dll'" />
+		</ItemGroup>
 
-    <Message Text="Copying @(XmlFiles ->'%(Identity)') to nupkg" Importance="high" Condition="'%(ProjectReference.NugetIgnore)'!='true'" />
+		<Message Text="Copying @(PdbFiles ->'%(Identity)') to nupkg" Importance="high" Condition="'%(ProjectReference.NugetIgnore)'!='true'" />
 
-    <ItemGroup>
-      <TfmSpecificPackageFile Include="@(XmlFiles)" Condition="'%(ProjectReference.NugetIgnore)'!='true'">
-        <PackagePath>lib/$(TargetFramework)</PackagePath>
-      </TfmSpecificPackageFile>
-    </ItemGroup>
-  </Target>
+		<ItemGroup>
+			<TfmSpecificPackageFile Include="@(PdbFiles)" Condition="'%(ProjectReference.NugetIgnore)'!='true'">
+				<PackagePath>lib/$(TargetFramework)</PackagePath>
+			</TfmSpecificPackageFile>
+		</ItemGroup>
+	</Target>
 
-  <!--code for signing-->
-  <!--<PropertyGroup>
+	<Target Name="CopyXmlToPackage" Inputs="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" Outputs="%(ProjectReference.Identity)" AfterTargets="CopyProjectReferencesToPackage">
+		<PropertyGroup>
+			<CurrentReference>%(ProjectReference.Identity)</CurrentReference>
+			<CurrentReferenceName>$([System.IO.Path]::GetFileNameWithoutExtension($(CurrentReference)))</CurrentReferenceName>
+		</PropertyGroup>
+
+		<ItemGroup>
+			<AllXmlItems Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('OriginalProjectReferenceItemSpec', '$(CurrentReference)'))" />
+			<XmlFiles Include="@(AllXmlItems -> '%(RelativeDir)%(Filename).xml')" Condition="%(extension) == '.dll'" />
+		</ItemGroup>
+
+		<Message Text="Copying @(XmlFiles ->'%(Identity)') to nupkg" Importance="high" Condition="'%(ProjectReference.NugetIgnore)'!='true'" />
+
+		<ItemGroup>
+			<TfmSpecificPackageFile Include="@(XmlFiles)" Condition="'%(ProjectReference.NugetIgnore)'!='true'">
+				<PackagePath>lib/$(TargetFramework)</PackagePath>
+			</TfmSpecificPackageFile>
+		</ItemGroup>
+	</Target>
+
+	<!--code for signing-->
+	<!--<PropertyGroup>
    <SignToolPath>C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64\signtool.exe</SignToolPath>
    <SigningCertificateSubjectName>your-subject</SigningCertificateSubjectName>
  </PropertyGroup>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.OAuth2PlatformClient.Diagnostics/Intuit.Ipp.OAuth2PlatformClient.Diagnostics.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.OAuth2PlatformClient.Diagnostics/Intuit.Ipp.OAuth2PlatformClient.Diagnostics.csproj
@@ -1,19 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include = "Serilog" Version="2.10.0" />
-    <PackageReference Include = "Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include = "Serilog.Sinks.File" Version="4.1.0" />
-    <PackageReference Include = "Serilog.Enrichers.Environment" Version="2.1.3" />
-    <PackageReference Include = "Serilog.Enrichers.Thread" Version="3.1.0" />
-    <PackageReference Include = "Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include = "Serilog.Settings.Configuration" Version="3.1.0" />
-    <PackageReference Include = "Serilog.Sinks.Debug" Version="2.0.0" />
-    <PackageReference Include = "Serilog.Sinks.Trace" Version="2.1.0" />
-    <PackageReference Include = "SerilogTraceListener" Version="3.2.0" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Serilog" Version="2.10.0" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+		<PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+		<PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
+		<PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
+		<PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+		<PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
+		<PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />
+		<PackageReference Include="SerilogTraceListener" Version="3.2.0" />
+	</ItemGroup>
 
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.OAuth2PlatformClient.Test/Intuit.Ipp.OAuth2PlatformClient.Test.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.OAuth2PlatformClient.Test/Intuit.Ipp.OAuth2PlatformClient.Test.csproj
@@ -1,55 +1,56 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.0</TargetFramework>
+		<OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Runtime" Version="4.3.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+		<PackageReference Include="System.Runtime" Version="4.3.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="Documents\discovery.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Documents\discovery_jwks.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Documents\failure_token_response.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Documents\failure_token_revocation_response.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Documents\success_refreshtoken_response.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Documents\success_revoketoken_response.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Documents\success_token_response.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="Documents\success_userinfo_response.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="Documents\discovery.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="Documents\discovery_jwks.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="Documents\failure_token_response.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="Documents\failure_token_revocation_response.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="Documents\success_refreshtoken_response.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="Documents\success_revoketoken_response.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="Documents\success_token_response.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="Documents\success_userinfo_response.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+</ItemGroup>
 
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.OAuth2PlatformClient/Intuit.Ipp.OAuth2PlatformClient.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.OAuth2PlatformClient/Intuit.Ipp.OAuth2PlatformClient.csproj
@@ -1,24 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Remove="Helpers\LogRequestsToDisk.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Remove="App.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
+	<ItemGroup>
+		<Compile Remove="Helpers\LogRequestsToDisk.cs" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Remove="App.config" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Serilog" Version="2.10.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 
-  </ItemGroup>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient.Diagnostics\Intuit.Ipp.OAuth2PlatformClient.Diagnostics.csproj" PrivateAssets="all"/>
-  </ItemGroup>
-  
+	<ItemGroup>
+		<ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient.Diagnostics\Intuit.Ipp.OAuth2PlatformClient.Diagnostics.csproj" PrivateAssets="all" />
+	</ItemGroup>
+
 
 
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.QueryFilter.Test/Intuit.Ipp.QueryFilter.Test.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.QueryFilter.Test/Intuit.Ipp.QueryFilter.Test.csproj
@@ -1,45 +1,45 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.0</TargetFramework>
+		<OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
 
-  </PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.QueryFilter\Intuit.Ipp.QueryFilter.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.QueryFilter\Intuit.Ipp.QueryFilter.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="AppSettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="TokenStore.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="AppSettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TokenStore.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+	</ItemGroup>
 
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.QueryFilter/Intuit.Ipp.QueryFilter.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.QueryFilter/Intuit.Ipp.QueryFilter.csproj
@@ -1,20 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+</ItemGroup>
 
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.ReportService.Test/Intuit.Ipp.ReportService.Test.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.ReportService.Test/Intuit.Ipp.ReportService.Test.csproj
@@ -1,40 +1,40 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.0</TargetFramework>
+		<OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
 
-  </PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.ReportService\Intuit.Ipp.ReportService.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.ReportService\Intuit.Ipp.ReportService.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="AppSettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TokenStore.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="AppSettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="TokenStore.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+</ItemGroup>
 
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.ReportService/Intuit.Ipp.ReportService.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.ReportService/Intuit.Ipp.ReportService.csproj
@@ -1,22 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Remove="app.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
+	<ItemGroup>
+		<None Remove="app.config" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+	</ItemGroup>
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Retry.Test/Intuit.Ipp.Retry.Test.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Retry.Test/Intuit.Ipp.Retry.Test.csproj
@@ -1,24 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.0</TargetFramework>
+		<OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+		<PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+	</ItemGroup>
 
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Retry/Intuit.Ipp.Retry.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Retry/Intuit.Ipp.Retry.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
-  
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+	</ItemGroup>
+
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Security.Test/Intuit.Ipp.Security.Test.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Security.Test/Intuit.Ipp.Security.Test.csproj
@@ -1,40 +1,41 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.0</TargetFramework>
+		<OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+		<PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="AppSettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TokenStore.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="AppSettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="TokenStore.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+</ItemGroup>
 
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Security/Intuit.Ipp.Security.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Security/Intuit.Ipp.Security.csproj
@@ -1,23 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Remove="MigratedTokenResponse.cs" />
-    <Compile Remove="OAuth1ToOAuth2TokenMigrationHelper.cs" />
-    <Compile Remove="OAuthRequestValidator.cs" />
-    <Compile Remove="SecurityConstants.cs" />
-    <None Remove="SecurityConstants.xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
+	<ItemGroup>
+		<Compile Remove="MigratedTokenResponse.cs" />
+		<Compile Remove="OAuth1ToOAuth2TokenMigrationHelper.cs" />
+		<Compile Remove="OAuthRequestValidator.cs" />
+		<Compile Remove="SecurityConstants.cs" />
+		<None Remove="SecurityConstants.xml" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+	</ItemGroup>
 </Project>
 
 

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Utility.Test/Intuit.Ipp.Utility.Test.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Utility.Test/Intuit.Ipp.Utility.Test.csproj
@@ -1,47 +1,48 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.0</TargetFramework>
+		<OutputPath>$(SolutionDir)\artifacts\tests</OutputPath>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Remove="App.config" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Remove="App.config" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.DataService\Intuit.Ipp.DataService.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="AppSettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TokenStore.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="AppSettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="TokenStore.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+	</ItemGroup>
 
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Utility/Intuit.Ipp.Utility.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Utility/Intuit.Ipp.Utility.csproj
@@ -1,33 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Remove="app.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Retry\Intuit.Ipp.Retry.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Update="Properties\Resources.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Update="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
+	<ItemGroup>
+		<None Remove="app.config" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Retry\Intuit.Ipp.Retry.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<Compile Update="Properties\Resources.Designer.cs">
+			<DesignTime>True</DesignTime>
+			<AutoGen>True</AutoGen>
+			<DependentUpon>Resources.resx</DependentUpon>
+		</Compile>
+	</ItemGroup>
+	<ItemGroup>
+		<EmbeddedResource Update="Properties\Resources.resx">
+			<Generator>ResXFileCodeGenerator</Generator>
+			<LastGenOutput>Resources.Designer.cs</LastGenOutput>
+		</EmbeddedResource>
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+	</ItemGroup>
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.WebHooksService/Intuit.Ipp.WebHooksService.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.WebHooksService/Intuit.Ipp.WebHooksService.csproj
@@ -1,27 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Remove="app.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="AppSettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
+	<ItemGroup>
+		<None Remove="app.config" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Update="AppSettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+	</ItemGroup>
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.WebhooksService.Test/Intuit.Ipp.WebhooksService.Test.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.WebhooksService.Test/Intuit.Ipp.WebhooksService.Test.csproj
@@ -1,40 +1,40 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp2.0</TargetFramework>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
 
-  </PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.6.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.WebHooksService\Intuit.Ipp.WebHooksService.csproj" />
+		<ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Tools\XsdExtension\Intuit.Ipp.Data\Intuit.Ipp.Data.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Core\Intuit.Ipp.Core.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Exception\Intuit.Ipp.Exception.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Security\Intuit.Ipp.Security.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.Utility\Intuit.Ipp.Utility.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.WebHooksService\Intuit.Ipp.WebHooksService.csproj" />
-    <ProjectReference Include="..\Intuit.Ipp.OAuth2PlatformClient\Intuit.Ipp.OAuth2PlatformClient.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="AppSettings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="AppSettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
+	</ItemGroup>
 
 </Project>

--- a/IPPDotNetDevKitCSV3/Code/IppDotNetDevKitCSV3.sln
+++ b/IPPDotNetDevKitCSV3/Code/IppDotNetDevKitCSV3.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.645
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32014.148
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Security", "Security", "{D65F7456-F8DB-4EC0-8C03-C22961C80649}"
 EndProject
@@ -54,6 +54,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
 		Local.testsettings = Local.testsettings
+		logo.png = logo.png
 		TraceAndTestImpact.testsettings = TraceAndTestImpact.testsettings
 	EndProjectSection
 EndProject
@@ -99,6 +100,7 @@ EndProject
 Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "TestSDK", "TestSDK\", "{2C20B529-1482-4BE7-B948-4AEE33A9889C}"
 	ProjectSection(WebsiteProperties) = preProject
 		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.6.1"
+		ProjectReferences = "{f9c4b669-e10b-44c4-8ed4-85ceaafc4126}|Intuit.Ipp.OAuth2PlatformClient.dll;{2147fc87-d172-40a6-9d54-181515daf7ac}|Intuit.Ipp.Core.dll;{e54bbdff-f3fb-4497-acec-7bc6f4404f71}|Intuit.Ipp.Data.dll;{2a5a9d95-9ce2-4726-a9e2-606838abdcd1}|Intuit.Ipp.DataService.dll;{d479ab56-8f3e-4c3e-b641-048b3552dda9}|Intuit.Ipp.QueryFilter.dll;{160733cb-f539-4545-bef4-f57176fd12de}|Intuit.Ipp.Security.dll;{0c815166-b7ac-45df-aa48-0b026687228e}|Intuit.Ipp.Exception.dll;{43c587bd-f5ee-46b8-a52a-bbd3ca6c1c74}|Intuit.Ipp.ReportService.dll;{34f2d8e7-2239-4ee0-ae53-3b8f6b0513bb}|Intuit.Ipp.Diagnostics.dll;"
 		Debug.AspNetCompiler.VirtualPath = "/localhost_65076"
 		Debug.AspNetCompiler.PhysicalPath = "TestSDK\"
 		Debug.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_65076\"
@@ -118,7 +120,7 @@ Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "TestSDK", "TestSDK\", "{2C2
 		DefaultWebSiteLanguage = "Visual C#"
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Intuit.Ipp.OAuth2PlatformClient.Diagnostics", "Intuit.Ipp.OAuth2PlatformClient.Diagnostics\Intuit.Ipp.OAuth2PlatformClient.Diagnostics.csproj", "{494E9C14-07CA-4CF3-AFD8-6C8D68F250C7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Intuit.Ipp.OAuth2PlatformClient.Diagnostics", "Intuit.Ipp.OAuth2PlatformClient.Diagnostics\Intuit.Ipp.OAuth2PlatformClient.Diagnostics.csproj", "{494E9C14-07CA-4CF3-AFD8-6C8D68F250C7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/IPPDotNetDevKitCSV3/Code/TestSDK/Default2.aspx.cs
+++ b/IPPDotNetDevKitCSV3/Code/TestSDK/Default2.aspx.cs
@@ -11,7 +11,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using Newtonsoft.Json;
+//using Newtonsoft.Json;
 using System.IO;
 using System.Net;
 using System.Security.Cryptography;

--- a/IPPDotNetDevKitCSV3/Tools/XsdExtension/Intuit.Ipp.XsdExtension/Intuit.Ipp.XsdExtension.csproj
+++ b/IPPDotNetDevKitCSV3/Tools/XsdExtension/Intuit.Ipp.XsdExtension/Intuit.Ipp.XsdExtension.csproj
@@ -1,49 +1,50 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net472</TargetFramework>
-    <AssemblyTitle>Intuit.Sb.CDM</AssemblyTitle>
-    <Product>Intuit.Sb.CDM</Product>
-    <DebugType>full</DebugType>
-    <DocumentationFile>$(BaseOutputPath)$(MSBuildProjectName).xml</DocumentationFile>
-    <AssemblyOriginatorKeyFile>..\..\..\Code\SigningKeys\DotNetSdkForQuickBooksApiV3.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Remove="App.config" />
-  </ItemGroup>
+	<PropertyGroup>
+		<ProductVersion>8.0.30703</ProductVersion>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net472</TargetFramework>
+		<AssemblyTitle>Intuit.Sb.CDM</AssemblyTitle>
+		<Product>Intuit.Sb.CDM</Product>
+		<DebugType>full</DebugType>
+		<DocumentationFile>$(BaseOutputPath)$(MSBuildProjectName).xml</DocumentationFile>
+		<AssemblyOriginatorKeyFile>..\..\..\Code\SigningKeys\DotNetSdkForQuickBooksApiV3.snk</AssemblyOriginatorKeyFile>
+		<Deterministic>false</Deterministic>
+	</PropertyGroup>
+	<ItemGroup>
+		<None Remove="App.config" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="DevDefined.OAuth" Version="0.2" />
-  
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Data.DataSetExtensions" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\..\Code\SigningKeys\DotNetSdkForQuickBooksApiV3.snk">
-      <Link>DotNetSdkForQuickBooksApiV3.snk</Link>
-    </None>
-    <None Include="Schema\Finance.xsd">
-      <SubType>Designer</SubType>
-    </None>
-    <None Include="Schema\IntuitBaseTypes.xsd">
-      <SubType>Designer</SubType>
-    </None>
-    <None Include="Schema\IntuitNamesTypes.xsd">
-      <SubType>Designer</SubType>
-    </None>
-    <None Include="Schema\IntuitRestServiceDef.xsd">
-      <SubType>Designer</SubType>
-    </None>
-    <None Include="Schema\Report.xsd">
-      <SubType>Designer</SubType>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\Code\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="DevDefined.OAuth" Version="0.2" />
+
+		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+	</ItemGroup>
+	<ItemGroup>
+		<Reference Include="System.Configuration" />
+		<Reference Include="System.Net.Http" />
+		<Reference Include="System.Data.DataSetExtensions" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="..\..\..\Code\SigningKeys\DotNetSdkForQuickBooksApiV3.snk">
+			<Link>DotNetSdkForQuickBooksApiV3.snk</Link>
+		</None>
+		<None Include="Schema\Finance.xsd">
+			<SubType>Designer</SubType>
+		</None>
+		<None Include="Schema\IntuitBaseTypes.xsd">
+			<SubType>Designer</SubType>
+		</None>
+		<None Include="Schema\IntuitNamesTypes.xsd">
+			<SubType>Designer</SubType>
+		</None>
+		<None Include="Schema\IntuitRestServiceDef.xsd">
+			<SubType>Designer</SubType>
+		</None>
+		<None Include="Schema\Report.xsd">
+			<SubType>Designer</SubType>
+		</None>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\Code\Intuit.Ipp.Diagnostics\Intuit.Ipp.Diagnostics.csproj" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #216 - Changes required to get IppDotNetDevKitCSV3 compiling on a machine with VS 2022.

Making these changes to the project files led to a successful build on my machine whereas, previously, hundreds of errors were being generated:

CSC : error CS0041: Unexpected error writing debug information -- 'Unable to load DLL 'Microsoft.DiaSymReader.Native.amd64.dll': The specified module could not be found. (Exception from HRESULT: 0x8007007E)'
6>Done building project "Intuit.Ipp.Diagnostics.csproj" -- FAILED.
