### PR TITLE
Set MaxDepth to be 256

### DIFF
--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Utility/Serialization/JsonObjectSerializer.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Utility/Serialization/JsonObjectSerializer.cs
@@ -74,6 +74,8 @@ namespace Intuit.Ipp.Utility
             settings.DateFormatHandling = DateFormatHandling.IsoDateFormat;
             settings.DateTimeZoneHandling = DateTimeZoneHandling.Utc;
             settings.DateFormatString = "yyyy-MM-ddTHH:mm:ssK";
+            settings.MaxDepth = 256;
+            
             try
             {
                 data = JsonConvert.SerializeObject(entity, settings);


### PR DESCRIPTION
Some complex General Ledger reports cannot be processed if the MaxDepth is not set (as it defaults to 64)