### PR TITLE
Extended exception retry strategy never called

### DIFF
--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/Retry/IntuitRetryPolicy.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/Retry/IntuitRetryPolicy.cs
@@ -332,7 +332,7 @@ namespace Intuit.Ipp.Core
                             var delay = TimeSpan.Zero;
 
                             // Check if we should continue retrying on this exception. If not, invoke the fault handler so that user code can take control.
-                            if (!IsTransient(lastError) || ((this.ExtendedRetryException != null) && this.ExtendedRetryException.IsRetryException(ex)))
+                            if (!(IsTransient(lastError) || ((this.ExtendedRetryException != null) && this.ExtendedRetryException.IsRetryException(ex))))
                             {
                                 faultHandler(lastError);
                                 return false;
@@ -557,7 +557,7 @@ namespace Intuit.Ipp.Core
                 {
                     lastError = ex;
 
-                    if (!IsTransient(lastError) || ((this.ExtendedRetryException != null) && this.ExtendedRetryException.IsRetryException(ex)))
+                    if (!(IsTransient(lastError) || ((this.ExtendedRetryException != null) && this.ExtendedRetryException.IsRetryException(ex))))
                     {
                         throw;
                     }


### PR DESCRIPTION
The `IExtendedRetry` logic was never called due to incorrect placement of parentheses resulting in the condition short circuiting if `IsTransient(lastError)` returned false. 

I've updated the tests to simulate a failure on the first call and complete on the subsequent retry.