### PR TITLE
Allow providing a custom HttpMessageHandler

### DIFF
--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.OAuth2PlatformClient/Client/DiscoveryClient.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.OAuth2PlatformClient/Client/DiscoveryClient.cs
@@ -110,10 +110,11 @@ namespace Intuit.Ipp.OAuth2PlatformClient
         /// DiscoveryClient constructor which takes in app environment
         /// </summary>
         /// <param name="appEnvironment">app Environment</param>
-        public DiscoveryClient(AppEnvironment appEnvironment)
+        /// <param name="innerHandler">innerHandler</param>
+        public DiscoveryClient(AppEnvironment appEnvironment, HttpMessageHandler innerHandler = null)
         {
             Policy.SetAuthority(appEnvironment);//Issuer url set, used in DiscoverResponse too for validation
-            var handler = new HttpClientHandler();
+            var handler = innerHandler ?? new HttpClientHandler();
             string url = "";
          
 

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.OAuth2PlatformClient/Client/OAuth2Client.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.OAuth2PlatformClient/Client/OAuth2Client.cs
@@ -165,7 +165,8 @@ namespace Intuit.Ipp.OAuth2PlatformClient
         /// <param name="clientSecret"></param>
         /// <param name="redirectURI"></param>
         /// <param name="environment">This can either be sandbox, production or an actual discovery url</param>
-        public OAuth2Client(string clientID, string clientSecret, string redirectURI, string environment)
+        /// <param name="innerHandler"></param>
+        public OAuth2Client(string clientID, string clientSecret, string redirectURI, string environment, HttpMessageHandler innerHandler = null)
         {
 
             ClientID = clientID ?? throw new ArgumentNullException(nameof(clientID));
@@ -189,7 +190,7 @@ namespace Intuit.Ipp.OAuth2PlatformClient
 
 
 
-            DiscoveryDoc = GetDiscoveryDoc();
+            DiscoveryDoc = GetDiscoveryDoc(innerHandler);
             
 
         }
@@ -235,8 +236,9 @@ namespace Intuit.Ipp.OAuth2PlatformClient
         /// <summary>
         /// Gets Discovery Doc
         /// </summary>
+        /// <param name="innerHandler">innerHandler</param>
         /// <returns></returns>
-        public DiscoveryResponse GetDiscoveryDoc()
+        public DiscoveryResponse GetDiscoveryDoc(HttpMessageHandler innerHandler = null)
         {
 
                 DiscoveryClient discoveryClient;
@@ -246,7 +248,7 @@ namespace Intuit.Ipp.OAuth2PlatformClient
                 }
                 else
                 {
-                    discoveryClient = new DiscoveryClient(ApplicationEnvironment);
+                    discoveryClient = new DiscoveryClient(ApplicationEnvironment, innerHandler);
                 }
                 DiscoveryResponse discoveryResponse =  discoveryClient.Get();
              if(discoveryResponse.IsError==true)
@@ -547,9 +549,10 @@ namespace Intuit.Ipp.OAuth2PlatformClient
         /// Gets Bearer token from Authorization code
         /// </summary>
         /// <param name="code"></param>
+        /// <param name="innerHandler"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<TokenResponse> GetBearerTokenAsync(string code, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<TokenResponse> GetBearerTokenAsync(string code, HttpMessageHandler innerHandler = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (string.IsNullOrEmpty(DiscoveryDoc.TokenEndpoint))
             {
@@ -577,7 +580,7 @@ namespace Intuit.Ipp.OAuth2PlatformClient
 
             }
 
-            var tokenClient = new TokenClient(DiscoveryDoc.TokenEndpoint, ClientID, ClientSecret);
+            var tokenClient = new TokenClient(DiscoveryDoc.TokenEndpoint, ClientID, ClientSecret, innerHandler);
             return await tokenClient.RequestTokenFromCodeAsync(code, RedirectURI, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
@@ -587,9 +590,10 @@ namespace Intuit.Ipp.OAuth2PlatformClient
         /// </summary>
         /// <param name="tokenEndpoint"></param>
         /// <param name="code"></param>
+        /// <param name="innerHandler"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<TokenResponse> GetBearerTokenAsync(string tokenEndpoint, string code, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<TokenResponse> GetBearerTokenAsync(string tokenEndpoint, string code, HttpMessageHandler innerHandler = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (string.IsNullOrEmpty(tokenEndpoint))
             {
@@ -618,7 +622,7 @@ namespace Intuit.Ipp.OAuth2PlatformClient
 
             }
 
-            var tokenClient = new TokenClient(tokenEndpoint, ClientID, ClientSecret);
+            var tokenClient = new TokenClient(tokenEndpoint, ClientID, ClientSecret, innerHandler);
             return await tokenClient.RequestTokenFromCodeAsync(code, RedirectURI, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
@@ -627,9 +631,10 @@ namespace Intuit.Ipp.OAuth2PlatformClient
         /// </summary>
         /// <param name="refreshToken"></param>
         /// <param name="extra"></param>
+        /// <param name="innerHandler"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<TokenResponse> RefreshTokenAsync(string refreshToken, object extra = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<TokenResponse> RefreshTokenAsync(string refreshToken, object extra = null, HttpMessageHandler innerHandler = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (string.IsNullOrEmpty(DiscoveryDoc.TokenEndpoint))
             {
@@ -657,7 +662,7 @@ namespace Intuit.Ipp.OAuth2PlatformClient
                 AdvancedLogger = LogHelper.GetAdvancedLogging(enableSerilogRequestResponseLoggingForDebug: this.EnableSerilogRequestResponseLoggingForDebug, enableSerilogRequestResponseLoggingForTrace: this.EnableSerilogRequestResponseLoggingForTrace, enableSerilogRequestResponseLoggingForConsole: this.EnableSerilogRequestResponseLoggingForConsole, enableSerilogRequestResponseLoggingForFile: this.EnableSerilogRequestResponseLoggingForFile, serviceRequestLoggingLocationForFile: this.ServiceRequestLoggingLocationForFile);
             }
 
-            var tokenClient = new TokenClient(DiscoveryDoc.TokenEndpoint, ClientID, ClientSecret);
+            var tokenClient = new TokenClient(DiscoveryDoc.TokenEndpoint, ClientID, ClientSecret, innerHandler);
             return await tokenClient.RequestRefreshTokenAsync(refreshToken, cancellationToken).ConfigureAwait(false);
         }
 
@@ -667,9 +672,10 @@ namespace Intuit.Ipp.OAuth2PlatformClient
         ///  <param name="tokenEndpoint"></param>
         /// <param name="refreshToken"></param>
         /// <param name="extra"></param>
+        /// <param name="innerHandler"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<TokenResponse> RefreshTokenAsync(string tokenEndpoint, string refreshToken, object extra = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<TokenResponse> RefreshTokenAsync(string tokenEndpoint, string refreshToken, object extra = null, HttpMessageHandler innerHandler = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (string.IsNullOrEmpty(tokenEndpoint))
             {
@@ -697,7 +703,7 @@ namespace Intuit.Ipp.OAuth2PlatformClient
                 AdvancedLogger = LogHelper.GetAdvancedLogging(enableSerilogRequestResponseLoggingForDebug: this.EnableSerilogRequestResponseLoggingForDebug, enableSerilogRequestResponseLoggingForTrace: this.EnableSerilogRequestResponseLoggingForTrace, enableSerilogRequestResponseLoggingForConsole: this.EnableSerilogRequestResponseLoggingForConsole, enableSerilogRequestResponseLoggingForFile: this.EnableSerilogRequestResponseLoggingForFile, serviceRequestLoggingLocationForFile: this.ServiceRequestLoggingLocationForFile);
             }
 
-            var tokenClient = new TokenClient(tokenEndpoint, ClientID, ClientSecret);
+            var tokenClient = new TokenClient(tokenEndpoint, ClientID, ClientSecret, innerHandler);
             return await tokenClient.RequestRefreshTokenAsync(refreshToken, cancellationToken).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
I would like to be able specify a custom HTTP message handler so that I can capture the 'intuit_tid' header and add it to our logs.

I've added an optional `HttpMessageHandler innerHandler = null` where it made sense and passed it through.

The following decisions were made:
* custom handler was not added to DiscoveryClient(string discoveryUrl), since there already exists another constructor DiscoveryClient(string authority = OidcConstants.Discovery.IssuerUrl, HttpMessageHandler innerHandler = null) which would conflict
* custom handler was not added to TokenClient in the constructor for RefreshTokenHandler, since there exists an overload where a TokenClient can be passed to the RefreshTokenHandler 