### PR TITLE
Allow run in sandbox

### DIFF
--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Exception/IdsError.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Exception/IdsError.cs
@@ -26,7 +26,7 @@ namespace Intuit.Ipp.Exception
     /// TODO: Update summary.
     /// </summary>
     [System.Serializable]
-    public class IdsError : System.Exception
+    public class IdsError : System.Exception, ISafeSerializationData
     {
         /// <summary>
         /// Error Code.
@@ -148,6 +148,7 @@ namespace Intuit.Ipp.Exception
             }
         }
 
+#if NETCORE
         /// <summary>
         /// Contains the System.Runtime.Serialization.SerializationInfo with information about the exception.
         /// </summary>
@@ -164,6 +165,20 @@ namespace Intuit.Ipp.Exception
                 info.AddValue("element", this.element);
                 info.AddValue("detail", this.detail);
             }
+        }
+#endif
+
+        /// <summary>
+        /// This method is called when the instance is deserialized.
+        /// </summary>
+        /// <param name="deserialized">An object that contains the state of the instance.</param>
+        public void CompleteDeserialization(object deserialized)
+        {
+            IdsError exception = (IdsError)deserialized;
+            exception.errorCode = this.errorCode;
+            exception.errorMessage = this.errorMessage;
+            exception.element = this.element;
+            exception.detail = this.detail;
         }
     }
 }

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Exception/IdsException.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Exception/IdsException.cs
@@ -29,7 +29,7 @@ namespace Intuit.Ipp.Exception
     /// Represents an IdsException.
     /// </summary>
     [System.Serializable]
-    public class IdsException : System.Exception
+    public class IdsException : System.Exception, ISafeSerializationData
     {
         /// <summary>
         /// Error Code.
@@ -283,6 +283,7 @@ namespace Intuit.Ipp.Exception
             }
         }
 
+#if NETCORE
         /// <summary>
         /// Contains the System.Runtime.Serialization.SerializationInfo with information about the exception.
         /// </summary>
@@ -300,6 +301,21 @@ namespace Intuit.Ipp.Exception
                 info.AddValue("innerException", this.innerException);
                 info.AddValue("innerExceptions", this.innerExceptions);
             }
+        }
+#endif
+
+        /// <summary>
+        /// This method is called when the instance is deserialized.
+        /// </summary>
+        /// <param name="deserialized">An object that contains the state of the instance.</param>
+        public void CompleteDeserialization(object deserialized)
+        {
+            IdsException exception = (IdsException)deserialized;
+            exception.errorCode = this.errorCode;
+            exception.errorMessage = this.errorMessage;
+            exception.source = this.source;
+            exception.innerException = this.innerException;
+            exception.innerExceptions = this.innerExceptions;
         }
     }
 }

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Nupkg/Intuit.Ipp.Nupkg.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Nupkg/Intuit.Ipp.Nupkg.csproj
@@ -6,7 +6,7 @@
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
     <LibTargetFrameworks>netstandard2.0;net472;net461</LibTargetFrameworks>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb;.xml</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <PackageId>IppDotNetSdkForQuickBooksApiV3</PackageId>
+    <PackageId>eWayIppDotNetSdkForQuickBooksApiV3</PackageId>
     <AssemblyName>IppDotNetSdkForQuickBooksApiV3</AssemblyName>
     <DocumentationFile>$(BaseOutputPath)$(AssemblyName).xml</DocumentationFile>
     <MainVersion>14.6.3.6</MainVersion>


### PR DESCRIPTION
It fixes issues like: 'Intuit.Ipp.Exception.IdsException.GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)'. Security accessibility of the overriding method must match the security accessibility of the method being overriden.

Can be seen in your forums too:
https://help.developer.intuit.com/s/question/0D5G000004Dk6wnKAB/error-inheritance-security-rules-violated-while-overriding-member-changed-trust-level-in-config-now-getting-please-specify-a-valid-directory-path-error-help
https://help.developer.intuit.com/s/question/0D5G000004Dk60PKAR/issue-deploying-ipp-net-sdk-v3

The problem is that starting .NET 4.0 GetObjectData is marked as SecurityCritical, but when assembly is in Sandbox mode it is SecurityTransparent, so the code cannot be executed.